### PR TITLE
Feature/auto generate validation docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ repositories {
     maven {
         url "https://artifactory.psdops.com/gyro-snapshots"
     }
+    maven {
+        url "https://artifactory.psdops.com/gyro-releases"
+    }
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'checkstyle'
 }
 
-version = "0.99.0-SNAPSHOT"
+version = "0.99.1-SNAPSHOT"
 
 defaultTasks 'shadowJar'
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ sourceCompatibility = 1.8
 dependencies {
     compile "com.google.guava:guava:23.0"
     compile 'com.psddev:dari-util:3.3.607-xe0f27a'
-    compile "gyro:gyro-core:0.99.0-SNAPSHOT"
+    compile "gyro:gyro-core:0.99.5"
     compile files("${System.getProperty('java.home')}/../lib/tools.jar")
 
     checkstyle 'com.puppycrawl.tools:checkstyle:8.15'

--- a/src/main/java/gyro/doclet/ResourceDocGenerator.java
+++ b/src/main/java/gyro/doclet/ResourceDocGenerator.java
@@ -16,24 +16,47 @@
 
 package gyro.doclet;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.google.common.base.CaseFormat;
+import com.psddev.dari.util.ObjectUtils;
 import com.psddev.dari.util.StringUtils;
 import com.sun.javadoc.AnnotationDesc;
+import com.sun.javadoc.AnnotationValue;
 import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.MethodDoc;
 import com.sun.javadoc.PackageDoc;
 import com.sun.javadoc.RootDoc;
 import com.sun.javadoc.Tag;
 import com.sun.javadoc.Type;
+import gyro.core.resource.Output;
+import gyro.core.validation.CollectionMax;
+import gyro.core.validation.CollectionMin;
+import gyro.core.validation.ConflictsWith;
+import gyro.core.validation.DependsOn;
+import gyro.core.validation.Max;
+import gyro.core.validation.Min;
+import gyro.core.validation.Range;
+import gyro.core.validation.Ranges;
+import gyro.core.validation.Regex;
+import gyro.core.validation.Regexes;
+import gyro.core.validation.Required;
+import gyro.core.validation.ValidNumbers;
+import gyro.core.validation.ValidStrings;
 
 public class ResourceDocGenerator {
 
     private static final Pattern LEADING_WHITE_SPACE = Pattern.compile("^\\s?");
     private static final Pattern LEADING_WHITE_SPACES = Pattern.compile("^\\s+");
+    private static final Pattern SEE_REF_DOC = Pattern.compile(" See `.*>`_\\.");
 
     private RootDoc root;
     private ClassDoc doc;
@@ -92,9 +115,7 @@ public class ResourceDocGenerator {
         generateHeader(sb);
 
         if (Arrays.stream(doc.methods())
-            .filter(e -> !StringUtils.isBlank(e.commentText()))
-            .findAny()
-            .isPresent()) {
+            .anyMatch(e -> !StringUtils.isBlank(e.commentText()))) {
             sb.append("Attributes\n");
             sb.append(repeat("-", 10));
             sb.append("\n\n");
@@ -174,14 +195,18 @@ public class ResourceDocGenerator {
 
     public static boolean isResource(ClassDoc classDoc) {
         boolean isResource = false;
-        ClassDoc superClass = classDoc.superclass();
-        while (superClass != null) {
-            if (superClass.name().equals("Resource")) {
-                isResource = true;
-                break;
-            }
 
-            superClass = superClass.superclass();
+        if (Arrays.stream(classDoc.annotations())
+            .anyMatch(o -> o.annotationType().qualifiedName().equals(gyro.core.Type.class.getName()))) {
+            ClassDoc superClass = classDoc.superclass();
+            while (superClass != null) {
+                if (superClass.name().equals("Resource")) {
+                    isResource = true;
+                    break;
+                }
+
+                superClass = superClass.superclass();
+            }
         }
 
         return isResource;
@@ -221,10 +246,20 @@ public class ResourceDocGenerator {
     }
 
     private boolean writeAttributes(ClassDoc classDoc, StringBuilder sb, int indent, boolean includeOutput) {
-        return writeAttributes(classDoc, sb, indent, includeOutput ? OutputMode.INCLUDE_OUTPUT : OutputMode.EXCLUDE_OUTPUT, true);
+        return writeAttributes(
+            classDoc,
+            sb,
+            indent,
+            includeOutput ? OutputMode.INCLUDE_OUTPUT : OutputMode.EXCLUDE_OUTPUT,
+            true);
     }
 
-    private boolean writeAttributes(ClassDoc classDoc, StringBuilder sb, int indent, OutputMode outputMode, boolean tableFormat) {
+    private boolean writeAttributes(
+        ClassDoc classDoc,
+        StringBuilder sb,
+        int indent,
+        OutputMode outputMode,
+        boolean tableFormat) {
         boolean hadOutputs = false;
 
         // Output superclass attributes.
@@ -240,19 +275,19 @@ public class ResourceDocGenerator {
             String commentText = methodDoc.commentText();
 
             if (commentText != null && commentText.length() > 0) {
+
+                commentText = addValidationAnnotationMessage(methodDoc, commentText);
+
                 String attributeName = methodDoc.name();
-                attributeName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, attributeName).replaceFirst("get-", "");
+                attributeName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_HYPHEN, attributeName)
+                    .replaceFirst("get-", "");
 
                 String attributeSubresourceClass = "";
                 boolean attributeIsOutput = false;
                 ResourceType attributeResourceType = null;
                 StringBuilder resourceLinkBuilder = new StringBuilder();
 
-                for (AnnotationDesc annotationDesc : methodDoc.annotations()) {
-                    if (annotationDesc.annotationType().name().equals("Output")) {
-                        attributeIsOutput = true;
-                    }
-                }
+                attributeIsOutput = isAnnotationPresent(methodDoc, Output.class);
 
                 for (Tag tag : methodDoc.tags()) {
                     if (tag.name().equals("@subresource")) {
@@ -282,7 +317,15 @@ public class ResourceDocGenerator {
                 if ((outputMode == OutputMode.INCLUDE_OUTPUT)
                     || (outputMode == OutputMode.EXCLUDE_OUTPUT && !attributeIsOutput)
                     || (outputMode == OutputMode.OUTPUT_ONLY && attributeIsOutput)) {
-                    writeAttribute(methodDoc, sb, attributeName, attributeResourceType, resourceLinkBuilder, commentText, indent, tableFormat);
+                    writeAttribute(
+                        methodDoc,
+                        sb,
+                        attributeName,
+                        attributeResourceType,
+                        resourceLinkBuilder,
+                        commentText,
+                        indent,
+                        tableFormat);
 
                     if (attributeResourceType == ResourceType.SUBRESOURCE) {
                         ClassDoc subresourceDoc = root.classNamed(attributeSubresourceClass);
@@ -302,7 +345,15 @@ public class ResourceDocGenerator {
         return hadOutputs;
     }
 
-    private void writeAttribute(MethodDoc methodDoc, StringBuilder sb, String attributeName, ResourceType resourceType, StringBuilder link, String commentText, int indent, boolean tableFormat) {
+    private void writeAttribute(
+        MethodDoc methodDoc,
+        StringBuilder sb,
+        String attributeName,
+        ResourceType resourceType,
+        StringBuilder link,
+        String commentText,
+        int indent,
+        boolean tableFormat) {
         String resourceTypeName = Optional.ofNullable(resourceType)
             .map(ResourceType::toString)
             .orElse(null);
@@ -342,7 +393,11 @@ public class ResourceDocGenerator {
         sb.append("\n\n");
     }
 
-    private void writeFieldName(StringBuilder sb, String attributeName, String genericTypeName, String resourceTypeName) {
+    private void writeFieldName(
+        StringBuilder sb,
+        String attributeName,
+        String genericTypeName,
+        String resourceTypeName) {
         sb.append(String.format(":attribute:`%s`", attributeName));
 
         if (genericTypeName != null) {
@@ -429,5 +484,327 @@ public class ResourceDocGenerator {
         public String toString() {
             return name().toLowerCase();
         }
+    }
+
+    private String addValidationAnnotationMessage(MethodDoc methodDoc, String commentText) {
+
+        String returnTypeName = methodDoc.returnType().typeName();
+
+        boolean isCollection = returnTypeName.equals("Set") || returnTypeName.equals("List");
+
+        // Exceptions for auto generating docs
+        Set<String> noDocSet = new HashSet<>();
+        Tag tag = Arrays.stream(methodDoc.tags()).filter(o -> o.name().equals("@no-doc")).findFirst().orElse(null);
+
+        if (tag != null) {
+            noDocSet = Arrays.stream(tag.text().split(",")).map(String::trim).collect(Collectors.toSet());
+        }
+
+        // Remove reference doc to be added later
+        Matcher matcher = SEE_REF_DOC.matcher(commentText);
+        String seeRefDoc = "";
+        if (matcher.find()) {
+            seeRefDoc = matcher.group();
+            commentText = commentText.replace(seeRefDoc, "");
+        }
+
+        // Conflicts With
+        if (isAnnotationPresent(methodDoc, ConflictsWith.class) && !noDocSet.contains("ConflictsWith")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, ConflictsWith.class);
+
+            List<String> conflictedFields = getAnnotationValues(annotationDesc);
+
+            String ConflictedFieldString = String.join("``, ``", conflictedFields);
+
+            // Replace last "," with an "or"
+            if (conflictedFields.size() > 1) {
+                ConflictedFieldString = String.format(
+                    "Cannot be set if any of ``%s or%s`` is set.",
+                    ConflictedFieldString.substring(0, ConflictedFieldString.lastIndexOf(",")),
+                    ConflictedFieldString.substring(ConflictedFieldString.lastIndexOf(",") + 1));
+            } else {
+                ConflictedFieldString = String.format("Cannot be set if ``%s`` is set.", ConflictedFieldString);
+            }
+
+            commentText = String.format("%s %s", commentText, ConflictedFieldString);
+        }
+
+        // Valid Strings
+        if (isAnnotationPresent(methodDoc, ValidStrings.class) && !noDocSet.contains("ValidStrings")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, ValidStrings.class);
+
+            List<String> validStringList = getAnnotationValues(annotationDesc);
+
+            String validString = String.join("``, ``", validStringList);
+
+            // Replace last "," with an "or"
+            if (validStringList.size() > 1) {
+                validString = String.format(
+                    "Valid values are ``%s %s%s``.",
+                    validString.substring(0, validString.lastIndexOf(",")),
+                    (isCollection ? "and" : "or"),
+                    validString.substring(validString.lastIndexOf(",") + 1));
+            } else {
+                validString = String.format("Currently the only supported value is ``%s``.", validString);
+            }
+
+            commentText = String.format("%s %s", commentText, validString);
+        }
+
+        // Valid Numbers
+        if (isAnnotationPresent(methodDoc, ValidNumbers.class) && !noDocSet.contains("ValidNumbers")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, ValidNumbers.class);
+
+            List<String> validNumberList = getAnnotationValues(annotationDesc);
+
+            String validNumber = String.join("``, ``", validNumberList);
+
+            // Replace last "," with an "or"
+            if (validNumberList.size() > 1) {
+                validNumber = String.format(
+                    "Valid values are ``%s %s%s`.",
+                    validNumber.substring(0, validNumber.lastIndexOf(",")),
+                    (isCollection ? "and" : "or"),
+                    validNumber.substring(validNumber.lastIndexOf(",") + 1));
+            } else {
+                validNumber = String.format("Currently the only supported value is ``%s``.", validNumber);
+            }
+
+            commentText = String.format("%s %s", commentText, validNumber);
+        }
+
+        // Depends on
+        if (isAnnotationPresent(methodDoc, DependsOn.class) && !noDocSet.contains("DependsOn")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, DependsOn.class);
+
+            List<String> dependentFields = getAnnotationValues(annotationDesc);
+
+            String dependentFieldString = String.join("``, ``", dependentFields);
+
+            // Replace last "," with an "and"
+            if (dependentFields.size() > 1) {
+                dependentFieldString = String.format(
+                    "Can only be set if all of ``%s and%s`` is set.",
+                    dependentFieldString.substring(0, dependentFieldString.lastIndexOf(",")),
+                    dependentFieldString.substring(dependentFieldString.lastIndexOf(",") + 1));
+            } else {
+                dependentFieldString = String.format("Can only be set if ``%s`` is set.", dependentFieldString);
+            }
+
+            commentText = String.format("%s %s", commentText, dependentFieldString);
+        }
+
+        // Max
+        if (isAnnotationPresent(methodDoc, Max.class) && !noDocSet.contains("Max")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, Max.class);
+
+            String maxValue = decimalTrimmed(getAnnotationValue(annotationDesc));
+
+            String maxFieldString = String.format("Maximum allowed value is ``%s``.", maxValue);
+
+            commentText = String.format("%s %s", commentText, maxFieldString);
+        }
+
+        // Min
+        if (isAnnotationPresent(methodDoc, Min.class) && !noDocSet.contains("Min")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, Min.class);
+
+            String maxValue = decimalTrimmed(getAnnotationValue(annotationDesc));
+
+            String minFieldString = String.format("Minimum allowed value is ``%s``.", maxValue);
+
+            commentText = String.format("%s %s", commentText, minFieldString);
+        }
+
+        // CollectionMax
+        if (isAnnotationPresent(methodDoc, CollectionMax.class) && !noDocSet.contains("CollectionMax")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, CollectionMax.class);
+
+            String collectionMaxValue = decimalTrimmed(getAnnotationValue(annotationDesc));
+
+            String collectionMaxFieldString = String.format("Maximum allowed items are ``%s``.", collectionMaxValue);
+
+            commentText = String.format("%s %s", commentText, collectionMaxFieldString);
+        }
+
+        // CollectionMin
+        if (isAnnotationPresent(methodDoc, CollectionMin.class) && !noDocSet.contains("CollectionMin")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, CollectionMin.class);
+
+            String collectionMinValue = decimalTrimmed(getAnnotationValue(annotationDesc));
+
+            String collectionMinFieldString = String.format("Minimum required items are ``%s``.", collectionMinValue);
+
+            commentText = String.format("%s %s", commentText, collectionMinFieldString);
+        }
+
+        // Range
+        if (isAnnotationPresent(methodDoc, Range.class) && !noDocSet.contains("Range")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, Range.class);
+
+            String maxValue = decimalTrimmed(getAnnotationValue(annotationDesc, "max"));
+            String minValue = decimalTrimmed(getAnnotationValue(annotationDesc, "min"));
+
+            String rangeFieldString = String.format("Valid values are between ``%s`` to ``%s``.", minValue, maxValue);
+
+            commentText = String.format("%s %s", commentText, rangeFieldString);
+        }
+
+        // Ranges
+        if (isAnnotationPresent(methodDoc, Ranges.class) && !noDocSet.contains("Range")
+            && !noDocSet.contains("Ranges")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, Ranges.class);
+
+            List<AnnotationDesc> annotationDescs = getAnnotationDescs(annotationDesc);
+            List<String> rangeFieldStrings = new ArrayList<>();
+
+            annotationDescs.forEach(o -> {
+                String maxValue = decimalTrimmed(getAnnotationValue(o, "max"));
+                String minValue = decimalTrimmed(getAnnotationValue(o, "min"));
+
+                rangeFieldStrings.add(String.format("``%s`` to ``%s``", minValue, maxValue));
+            });
+
+            String join = String.join(", ", rangeFieldStrings);
+            String rangesFieldString = String.format(
+                "Valid values are between %s and%s.",
+                join.substring(0, join.lastIndexOf(",")),
+                join.substring(join.lastIndexOf(",") + 1));
+
+            commentText = String.format("%s %s", commentText, rangesFieldString);
+        }
+
+        // Regex
+        if (isAnnotationPresent(methodDoc, Regex.class) && !noDocSet.contains("Regex")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, Regex.class);
+
+            String regexValue = StringUtils.escapeJava(getAnnotationValue(annotationDesc, "value"));
+            String regexMessage = getAnnotationValue(annotationDesc, "message");
+
+            String validRegexMessage = !ObjectUtils.isBlank(regexMessage)
+                ? String.format("Must be %s.", regexMessage)
+                : "";
+
+            String regexFieldString = String.format(
+                "%s Valid values satisfy the regex: ``[%s]``.",
+                validRegexMessage,
+                regexValue);
+
+            commentText = String.format("%s %s", commentText, regexFieldString);
+        }
+
+        // Regexes
+        if (isAnnotationPresent(methodDoc, Regexes.class) && !noDocSet.contains("Regex")
+            && !noDocSet.contains("Regexes")) {
+            AnnotationDesc annotationDesc = getAnnotationDesc(methodDoc, Regexes.class);
+
+            List<AnnotationDesc> annotationDescs = getAnnotationDescs(annotationDesc);
+            List<String> regexFieldStrings = new ArrayList<>();
+
+            annotationDescs.forEach(o -> {
+                String regexValue = StringUtils.escapeJava(getAnnotationValue(o, "value"));
+                String regexMessage = getAnnotationValue(o, "message");
+
+                String validRegexMessage = !ObjectUtils.isBlank(regexMessage)
+                    ? String.format("Must be %s.", regexMessage)
+                    : "";
+
+                regexFieldStrings.add(String.format(
+                    "%s Valid values satisfy the regex: ``[%s]``.",
+                    validRegexMessage,
+                    regexValue));
+            });
+
+            String rangesFieldString = String.format(
+                "Valid values satisfy one of the following regexes: \n\n %s",
+                String.join("\n", regexFieldStrings));
+
+            commentText = String.format("%s %s", commentText, rangesFieldString);
+        }
+
+        // See Ref Doc
+        // Has to be before Required
+        if (!ObjectUtils.isBlank(seeRefDoc)) {
+            commentText = String.format("%s %s", commentText, seeRefDoc);
+        }
+
+        // Required
+        // Has to be the last one
+        if (isAnnotationPresent(methodDoc, Required.class)) {
+            commentText = String.format("%s %s", commentText, "(Required)");
+        }
+
+        commentText = commentText.replaceAll("\\.\\.", ".")
+            .replaceAll("@\\|bold\\s+", "``")
+            .replaceAll("\\|@", "``");
+
+        return commentText;
+    }
+
+    private boolean isAnnotationPresent(MethodDoc methodDoc, Class<?> annotationClass) {
+        return Arrays.stream(methodDoc.annotations())
+            .anyMatch(o -> o.annotationType().qualifiedName().equals(annotationClass.getName()));
+    }
+
+    private AnnotationDesc getAnnotationDesc(MethodDoc methodDoc, Class<?> annotationClass) {
+        return Arrays.stream(methodDoc.annotations())
+            .filter(o -> o.annotationType().qualifiedName().equals(annotationClass.getName()))
+            .findFirst()
+            .orElse(null);
+    }
+
+    private List<String> getAnnotationValues(AnnotationDesc annotationDesc) {
+        AnnotationDesc.ElementValuePair elementValuePair = annotationDesc.elementValues()[0];
+        AnnotationValue[] values = (AnnotationValue[]) elementValuePair.value().value();
+
+        return Arrays.stream(values).map(o -> o.value().toString()).collect(Collectors.toList());
+    }
+
+    private String getAnnotationValue(AnnotationDesc annotationDesc) {
+        return getAnnotationValue(annotationDesc, "value");
+    }
+
+    private String getAnnotationValue(AnnotationDesc annotationDesc, String elementName) {
+        String returnValue = "";
+
+        AnnotationDesc.ElementValuePair elementValuePair = Arrays.stream(annotationDesc.elementValues())
+            .filter(o -> o.element().name().equals(elementName))
+            .findFirst()
+            .orElse(null);
+
+        if (elementValuePair != null) {
+            Object value = elementValuePair.value().value();
+            if (value instanceof Number) {
+                if (value instanceof Integer) {
+                    returnValue = String.format("%d", value);
+                } else {
+                    returnValue = String.format("%f", value);
+                }
+            } else {
+                returnValue = elementValuePair.value().value().toString();
+            }
+        }
+
+        return returnValue;
+    }
+
+    private List<AnnotationDesc> getAnnotationDescs(AnnotationDesc annotationDesc) {
+        AnnotationDesc.ElementValuePair elementValuePair = annotationDesc.elementValues()[0];
+        AnnotationValue[] values = (AnnotationValue[]) elementValuePair.value().value();
+
+        return Arrays.stream(values).map(o -> (AnnotationDesc) o.value()).collect(Collectors.toList());
+    }
+
+    private String decimalTrimmed(String num) {
+        String result = num;
+        String[] split = num.split("\\.");
+        if (split.length == 2) {
+            String decimal = split[1].replaceAll("0", "");
+            if (ObjectUtils.isBlank(decimal)) {
+                result = split[0];
+            }
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
Fixes #19 

 The change autogenerates documentation for fields based on the validation annotations

 - @Required: Autogens ``(Required)`` to the end of the existing doc.
 
 - @ConflictsWith: Autogens ``Cannot be set if any of <field1> or <field2> is set`` to the doc.
     - If the annoataion is on a Collection type field

 - @ValidStrings: Autogens ``Valid values are <value1>, <value2> or <value3>`` to the doc.
     - If the annotation is on a Collection type field the ``or`` is replaced with an ``and``.
     - If the annotation only has one value then the generated doc is ``Currently the only supported value is <value>``.

**Note: For enum type fields, it is recommended to use @ValidStrings annotation on it, so the doclet can autogen the corresponding documentation.

 - @ValidNumbers: Autogens ``Valid values are <value1>, <value2> or <value3>`` to the doc.
     - If the annotation is on a Collection type field the ``or`` is replaced with an ``and``.
     - If the annotation only has one value then the generated doc is ``Currently the only supported value is <value>``.

 - @DependsOn: Autogens ``Can only be set if all of <field1>, <Field2> and <field3> is set`` to the doc.
     - If the annotation only has one value then the generated doc is ``Can only be set if <field> is set``.

 - @Max: Autogens ``Maximum allowed value is <value>`` to the doc.

 - @Min: Autogens ``Minimum allowed value is <value>`` to the doc.

 - @CollectionMax: Autogens ``Maximum allowed items are <value>`` to the doc.

 - @CollectionMin: Autogens ``Minimum allowed items are <value>`` to the doc.

 - @Range: Autogens ``Valid values are between <lower_value> to <upper_value>`` to the doc.
     - If multiple ``@Range`` or a single ``@Ranges`` annotation is used, then the generated doc is ``Valid values are between <lower_value1> to <upper_value1>, <lower_value2> to <upper_value2> and <lower_value3> to <upper_value3>``.

 - @Regex: Autogens ``Must be <regex_message>. Valid values satisfy the regex: [<regex-expression>]`` to the docs.
     - If the message is not provided in the annotation then the generated doc is ``Valid values satisfy the regex: [<regex-expression>]``.
     - If multiple ``@Regex`` or a single ``@Regexes`` annotation is used, then the generated doc is 
        ```
        Valid values satisfy one of the following regexes:
       
        Must be <regex_message1>. Valid values satisfy the regex: [<regex-expression1>]
        Must be <regex_message2>. Valid values satisfy the regex: [<regex-expression2>]
        Must be <regex_message3>. Valid values satisfy the regex: [<regex-expression3>]
        ```

A new tag is also introduced ``@no-doc``.
This can be used to stop the doclet from auto generating documentation based on the provided annotation name.

Usage:
```
/**
*
* @no-doc <Annoation1>, <Annotation2>
*/
```

Example:
```
/**
     * Peer BGP Autonomous System Number (ASN). Valid values belong in between ``64512`` to ``65534`` for a 16-bit ASN or between ``4200000000`` to ``4294967294`` for a 32-bit ASN.
     *
     * @no-doc Range, Ranges
     */
    @Required
    @Range(min = 64512, max = 65534)
    @Range(min = 4200000000L, max = 4294967294L)
    public Long getPeerAsn() {}
``` 
In this case docs for ``@Required``will be autogenerated but not for ``@Range``. 

** Note: The annotation names provided to this ``@no-doc`` tag is case sensitive, and so should respect the exact class name of the annotation 






